### PR TITLE
method to change baseUrl, new baseUrl

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var zlib, Promise, baseUrl, cheerio, getCategories, parseCategories, parsePage, parseResults, recentTorrents, userTorrents, request, search, topTorrents;
+var zlib, Promise, baseUrl, cheerio, getCategories, parseCategories, parsePage, parseResults, recentTorrents, userTorrents, request, search, topTorrents, setUrl;
 
 request = require('request');
 
@@ -6,7 +6,7 @@ cheerio = require('cheerio');
 
 Promise = require('es6-promise').Promise;
 
-baseUrl = 'http://thepiratebay.se';
+baseUrl = 'http://thepiratebay.am';
 
 zlib = require('zlib');
 
@@ -307,6 +307,10 @@ parseResults = function(resultsHTML) {
     return results.get();
 };
 
+setUrl = function(url) {
+  baseUrl = url;
+};
+
 exports.search         = search;
 exports.topTorrents    = topTorrents;
 exports.recentTorrents = recentTorrents;
@@ -315,3 +319,4 @@ exports.getCategories  = getCategories;
 exports.tvShows        = tvShows;
 exports.getTvShow      = getTvShow;
 exports.getTorrent     = getTorrent;
+exports.setUrl         = setUrl;

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -1,5 +1,8 @@
 scraper = require '../'
 
+baseUrl = 'http://thepiratebay.am'
+scraper.setUrl(baseUrl)
+
 describe 'scraper', ->
 
   describe 'scraper.getTorrent(id)', ->
@@ -51,7 +54,7 @@ describe 'scraper', ->
 
       it 'should have a link', ->
         torrent.should.have.property 'link'
-        torrent.link.should.equal 'http://thepiratebay.se/torrent/10676856'
+        torrent.link.should.equal "#{baseUrl}/torrent/10676856"
 
       it 'should have a magnet link', ->
         torrent.should.have.property 'magnetLink'
@@ -127,7 +130,7 @@ describe 'scraper', ->
       it 'should have a link', ->
         results[0].should.have.property 'link'
         #e.g http://thepiratebay.se/torrent/9897245/Game_of_Thrones_Season_3_[Hard_Subs_in_English__AVI_format]
-        results[0].link.should.match /http:\/\/thepiratebay.se\/torrent\/\d+\/.+/
+        results[0].link.should.match new RegExp(baseUrl + '/torrent/\\d+/\.+')
 
       it 'should have a magnet link', ->
         results[0].should.have.property 'magnetLink'
@@ -267,7 +270,7 @@ describe 'scraper', ->
       it 'should have a link', ->
         results[0].should.have.property 'link'
         #e.g http://thepiratebay.se/torrent/9897245/Game_of_Thrones_Season_3_[Hard_Subs_in_English__AVI_format]
-        results[0].link.should.match /http:\/\/thepiratebay.se\/torrent\/\d+\/.+/
+        results[0].link.should.match new RegExp(baseUrl + '/torrent/\\d+/\.+')
 
       it 'should have a magnet link', ->
         results[0].should.have.property 'magnetLink'


### PR DESCRIPTION
thepiratebay [changed](https://torrentfreak.com/pirate-bay-moves-to-gs-la-vg-am-mn-and-gd-domains-150519/) `.se` domain recently 