### PR TITLE
Fix searching for the empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ search = function(title, opts, cb) {
     query = {
         url: baseUrl + '/s/',
         qs: {
-            q: title || '',
+            q: title || '*',
             category: opts.category || '0',
             page: opts.page || '0',
             orderby: opts.orderBy || '99'


### PR DESCRIPTION
This fixes issue 12. The problem was that when you search for the empty string on TPB, it redirects to /recent, so this fix just changes the query to * if it's empty, which works just fine.