### PR TITLE
propagate parsing exceptions from 'parse(data)'

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,7 +99,12 @@ parsePage = function(url, parse, cb) {
             if (err) {
                 cb(err);
             } else {
-              categories = parse(data);
+              try {
+                categories = parse(data);
+              }
+              catch(err) {
+                return cb(err);
+              }
               return cb(null, categories);
             }
         });
@@ -110,7 +115,12 @@ parsePage = function(url, parse, cb) {
             if (err) {
                 reject(err);
             } else {
-                categories = parse(data);
+                try {
+                  categories = parse(data);
+                }
+                catch(err) {
+                  return reject(err)
+                }
                 return resolve(categories);
             }
         })


### PR DESCRIPTION
... in particular from time to time 'parseResults' function fails on this line: 

uploadDate = $(this).find('font').text().match(/Uploaded\s(?:<b>)?(.+?)(?:<\/b>)?,/)[1];

at the moment it leads to unhandled exception