### PR TITLE
Change baseUrl

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ cheerio = require('cheerio');
 
 Promise = require('es6-promise').Promise;
 
-baseUrl = 'http://thepiratebay.mn';
+baseUrl = 'http://thepiratebay.se';
 
 zlib = require('zlib');
 

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -1,6 +1,6 @@
 scraper = require '../'
 
-baseUrl = 'http://thepiratebay.mn'
+baseUrl = 'http://thepiratebay.se'
 scraper.setUrl(baseUrl)
 
 describe 'scraper', ->


### PR DESCRIPTION
TLD `.mn` no longer resolves. Changed to `.se`.