### PR TITLE
ignore cloudflare js redirects

### DIFF
--- a/src/Parser.js
+++ b/src/Parser.js
@@ -88,8 +88,9 @@ export function parsePage(url: string, parseCallback: parseCallbackType, filter:
             body.includes('502: Bad gateway') ||
             body.includes('403 Forbidden') ||
             body.includes('Database maintenance') ||
+            body.includes('Checking your browser before accessing') ||
             body.includes('Origin DNS error')
-              ? Promise.reject('Database maintenance, Cloudflare DNS error, 403 or 502 error')
+              ? Promise.reject('Database maintenance, Cloudflare problems, 403 or 502 error')
               : Promise.resolve(body)
         )
       ));


### PR DESCRIPTION
thepiratebay is currently not working.
There is a problem with `https://pirateproxy.one`. It uses cloudflare browser check before redirecting.
The parser does not support this behavior at the moment. I added a ignore-rule to To ignore this kind of proxies.

Another solution would be to remove `https://pirateproxy.one`.